### PR TITLE
Implement install inventory

### DIFF
--- a/pkg/drop/dropper.go
+++ b/pkg/drop/dropper.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/carabiner-dev/drop/pkg/github"
 )
 
@@ -181,6 +183,12 @@ func (dropper *Dropper) Install(spec github.AssetDataProvider, funcs ...FuncGetO
 	// Install the asset in the system
 	if err := dropper.impl.InstallAsset(&opts, sysinfo, artifact, downloadPath); err != nil {
 		return fmt.Errorf("installing asset: %w", err)
+	}
+
+	// Register the installation in the inventory. The app is already
+	// installed at this point, so a recording failure is not fatal.
+	if err := dropper.impl.RecordInstall(&opts, artifact, downloadPath, !opts.SkipVerification); err != nil {
+		logrus.Warnf("app installed, but recording it in the inventory failed: %v", err)
 	}
 
 	return nil

--- a/pkg/drop/implementation.go
+++ b/pkg/drop/implementation.go
@@ -60,10 +60,18 @@ type installerImplementation interface {
 	// InstallAsset invokes the system mechanism to set up the downloaded artifact
 	// in the local machine.
 	InstallAsset(*GetOptions, *system.Info, *InstallArtifact, string) error
+
+	// RecordInstall registers a successful installation in the user's
+	// inventory database so it can later be verified, updated or removed.
+	RecordInstall(*GetOptions, *InstallArtifact, string, bool) error
 }
 
 type defaultImplementation struct {
 	runner commandRunner
+
+	// inventoryPath overrides the location of the inventory database,
+	// when empty the default (in the user's config dir) is used.
+	inventoryPath string
 }
 
 func (di *defaultImplementation) GetSystemInfo(*Options) (*system.Info, error) {

--- a/pkg/drop/install.go
+++ b/pkg/drop/install.go
@@ -5,6 +5,8 @@ package drop
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -15,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/carabiner-dev/drop/pkg/github"
+	"github.com/carabiner-dev/drop/pkg/inventory"
 	"github.com/carabiner-dev/drop/pkg/system"
 )
 
@@ -489,6 +492,70 @@ func (di *defaultImplementation) installBinary(
 			"path":      target,
 		},
 	})
+	return nil
+}
+
+// fileDigest returns the hex-encoded sha256 hash of a file.
+func fileDigest(path string) (string, error) {
+	f, err := os.Open(path) //nolint:gosec
+	if err != nil {
+		return "", fmt.Errorf("opening file to hash: %w", err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("hashing file: %w", err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// RecordInstall registers a successful installation in the user's inventory
+// database so it can later be verified, updated or removed.
+func (di *defaultImplementation) RecordInstall(
+	opts *GetOptions, artifact *InstallArtifact, downloadPath string, verified bool,
+) error {
+	var inv *inventory.Inventory
+	var err error
+	if di.inventoryPath == "" {
+		inv, err = inventory.Open()
+	} else {
+		inv, err = inventory.OpenFile(di.inventoryPath)
+	}
+	if err != nil {
+		return fmt.Errorf("opening install inventory: %w", err)
+	}
+
+	// Hash the verified artifact. For binaries this is the same content
+	// that landed in the binaries directory.
+	digest, err := fileDigest(downloadPath)
+	if err != nil {
+		return err
+	}
+
+	record := &inventory.Record{
+		Host:     artifact.Asset.GetHost(),
+		Org:      artifact.Asset.GetOrg(),
+		Repo:     artifact.Asset.GetRepo(),
+		Name:     strings.TrimSuffix(artifact.InstallName, exeSuffix),
+		Version:  artifact.Asset.GetVersion(),
+		Kind:     string(artifact.Kind),
+		Asset:    artifact.Asset.GetName(),
+		Digest:   map[string]string{"sha256": digest},
+		Verified: verified,
+	}
+
+	switch artifact.Kind {
+	case ArtifactBinary:
+		record.BinPath = filepath.Join(opts.BinDir, artifact.InstallName)
+	case ArtifactPackage:
+		record.PackageFormat = artifact.PackageFormat
+	}
+
+	inv.Add(record)
+	if err := inv.Save(); err != nil {
+		return fmt.Errorf("saving install inventory: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/drop/install_test.go
+++ b/pkg/drop/install_test.go
@@ -4,6 +4,8 @@
 package drop
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/carabiner-dev/drop/pkg/github"
+	"github.com/carabiner-dev/drop/pkg/inventory"
 	"github.com/carabiner-dev/drop/pkg/system"
 )
 
@@ -422,4 +425,81 @@ func TestDownloadAssetToTmp(t *testing.T) {
 	data, err := os.ReadFile(path) //nolint:gosec // path is a test-controlled tmp file
 	require.NoError(t, err)
 	require.Equal(t, "artifact-data", string(data))
+}
+
+func TestRecordInstall(t *testing.T) {
+	t.Parallel()
+	content := []byte("artifact-data")
+	sum := sha256.Sum256(content)
+	wantDigest := hex.EncodeToString(sum[:])
+
+	asset := &github.Asset{
+		Host:    "github.com",
+		Org:     "carabiner-dev",
+		Repo:    testAppName,
+		Version: "v0.1.0",
+		Name:    testBinFile,
+		Os:      system.OSLinux,
+		Arch:    system.ArchAMD64,
+	}
+
+	for _, tc := range []struct {
+		name     string
+		artifact *InstallArtifact
+		verified bool
+		check    func(t *testing.T, r *inventory.Record)
+	}{
+		{
+			name: "binary",
+			artifact: &InstallArtifact{
+				Kind: ArtifactBinary, Asset: asset, InstallName: testAppName,
+			},
+			verified: true,
+			check: func(t *testing.T, r *inventory.Record) {
+				t.Helper()
+				require.Equal(t, string(ArtifactBinary), r.Kind)
+				require.Equal(t, filepath.Join("/opt/bin", testAppName), r.BinPath)
+				require.Empty(t, r.PackageFormat)
+				require.True(t, r.Verified)
+			},
+		},
+		{
+			name: "package-unverified",
+			artifact: &InstallArtifact{
+				Kind: ArtifactPackage, PackageFormat: system.PackageRPM,
+				Asset: asset, InstallName: testAppName,
+			},
+			verified: false,
+			check: func(t *testing.T, r *inventory.Record) {
+				t.Helper()
+				require.Equal(t, string(ArtifactPackage), r.Kind)
+				require.Equal(t, system.PackageRPM, r.PackageFormat)
+				require.Empty(t, r.BinPath)
+				require.False(t, r.Verified)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			downloaded := filepath.Join(t.TempDir(), testBinFile)
+			require.NoError(t, os.WriteFile(downloaded, content, 0o600))
+
+			invPath := filepath.Join(t.TempDir(), "installed.json")
+			di := &defaultImplementation{inventoryPath: invPath}
+			opts := &GetOptions{BinDir: "/opt/bin"}
+
+			require.NoError(t, di.RecordInstall(opts, tc.artifact, downloaded, tc.verified))
+
+			inv, err := inventory.OpenFile(invPath)
+			require.NoError(t, err)
+			record := inv.Get("github.com/carabiner-dev/drop#drop")
+			require.NotNil(t, record)
+			require.Equal(t, testAppName, record.Name)
+			require.Equal(t, "v0.1.0", record.Version)
+			require.Equal(t, testBinFile, record.Asset)
+			require.Equal(t, map[string]string{"sha256": wantDigest}, record.Digest)
+			require.False(t, record.InstalledAt.IsZero())
+			tc.check(t, record)
+		})
+	}
 }

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// Package inventory keeps track of the artifacts drop installs in the local
+// system. The data lives in a single versioned JSON document in the user's
+// configuration directory and records, for every installed app, what was
+// installed and enough metadata to later verify, update or uninstall it.
+package inventory
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Version is the current schema version of the inventory file.
+const Version = 1
+
+const dirName = "drop"
+
+// FileName is the name of the inventory database file.
+const FileName = "installed.json"
+
+// Inventory is the database of artifacts installed by drop.
+type Inventory struct {
+	Version  int                `json:"version"`
+	Installs map[string]*Record `json:"installs"`
+
+	path string
+}
+
+// Record stores the data of one installed app.
+type Record struct {
+	// Repository coordinates and installable name identifying the app.
+	Host string `json:"host"`
+	Org  string `json:"org"`
+	Repo string `json:"repo"`
+	Name string `json:"name"`
+
+	// Version is the release tag the installed artifact came from.
+	Version string `json:"version"`
+
+	// Kind is the artifact type that was installed (binary or package).
+	Kind string `json:"kind"`
+
+	// Asset is the exact release asset that was downloaded.
+	Asset string `json:"asset"`
+
+	// Digest captures the hashes of the verified artifact, keyed by
+	// algorithm. For binaries it can be checked against the installed
+	// file, for packages integrity checks are delegated to the package
+	// manager and the digest ties the record to the verified file.
+	Digest map[string]string `json:"digest,omitempty"`
+
+	// BinPath is the path where the binary was installed (binaries only).
+	BinPath string `json:"binPath,omitempty"`
+
+	// PackageFormat is the package type handed to the package manager
+	// (packages only).
+	PackageFormat string `json:"packageFormat,omitempty"`
+
+	// Verified records if the artifact passed policy verification or was
+	// installed with verification disabled.
+	Verified bool `json:"verified"`
+
+	InstalledAt time.Time `json:"installedAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+// Key returns the string keying the record in the inventory.
+func (r *Record) Key() string {
+	return fmt.Sprintf("%s/%s/%s#%s", r.Host, r.Org, r.Repo, r.Name)
+}
+
+// DefaultPath returns the location of the inventory database in the user's
+// configuration directory.
+func DefaultPath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving user configuration directory: %w", err)
+	}
+	return filepath.Join(dir, dirName, FileName), nil
+}
+
+// Open loads the inventory from its default location, returning an empty
+// inventory if no database exists yet.
+func Open() (*Inventory, error) {
+	path, err := DefaultPath()
+	if err != nil {
+		return nil, err
+	}
+	return OpenFile(path)
+}
+
+// OpenFile loads the inventory from a file, returning an empty inventory
+// bound to the path if the file does not exist yet.
+func OpenFile(path string) (*Inventory, error) {
+	inv := &Inventory{
+		Version:  Version,
+		Installs: map[string]*Record{},
+		path:     path,
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // reading the inventory is the point
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return inv, nil
+		}
+		return nil, fmt.Errorf("reading inventory: %w", err)
+	}
+
+	if err := json.Unmarshal(data, inv); err != nil {
+		return nil, fmt.Errorf("parsing inventory: %w", err)
+	}
+
+	if inv.Version > Version {
+		return nil, fmt.Errorf("inventory version %d is newer than the supported version %d", inv.Version, Version)
+	}
+
+	if inv.Installs == nil {
+		inv.Installs = map[string]*Record{}
+	}
+	return inv, nil
+}
+
+// Save atomically writes the inventory back to the file it was loaded from.
+func (inv *Inventory) Save() error {
+	if inv.path == "" {
+		return errors.New("inventory is not bound to a file")
+	}
+
+	dir := filepath.Dir(inv.path)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("creating inventory directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(inv, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling inventory: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".installed-*.json")
+	if err != nil {
+		return fmt.Errorf("creating temporary file: %w", err)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()           //nolint:errcheck
+		_ = os.Remove(tmp.Name()) //nolint:errcheck
+		return fmt.Errorf("writing inventory: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name()) //nolint:errcheck
+		return fmt.Errorf("closing inventory file: %w", err)
+	}
+
+	if err := os.Rename(tmp.Name(), inv.path); err != nil {
+		_ = os.Remove(tmp.Name()) //nolint:errcheck
+		return fmt.Errorf("replacing inventory: %w", err)
+	}
+	return nil
+}
+
+// Add upserts a record into the inventory. When the app is already recorded,
+// the original installation timestamp is preserved.
+func (inv *Inventory) Add(record *Record) {
+	now := time.Now().UTC()
+	key := record.Key()
+	if existing, ok := inv.Installs[key]; ok && !existing.InstalledAt.IsZero() {
+		record.InstalledAt = existing.InstalledAt
+	} else if record.InstalledAt.IsZero() {
+		record.InstalledAt = now
+	}
+	record.UpdatedAt = now
+	inv.Installs[key] = record
+}
+
+// Get returns the record stored under a key or nil if there is none.
+func (inv *Inventory) Get(key string) *Record {
+	return inv.Installs[key]
+}
+
+// Remove deletes the record stored under a key, returning true if it existed.
+func (inv *Inventory) Remove(key string) bool {
+	_, ok := inv.Installs[key]
+	delete(inv.Installs, key)
+	return ok
+}

--- a/pkg/inventory/inventory_test.go
+++ b/pkg/inventory/inventory_test.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package inventory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testRecord() *Record {
+	return &Record{
+		Host:     "github.com",
+		Org:      "carabiner-dev",
+		Repo:     "drop",
+		Name:     "drop",
+		Version:  "v0.1.0",
+		Kind:     "binary",
+		Asset:    "drop-v0.1.0-linux-amd64",
+		Digest:   map[string]string{"sha256": "abc123"},
+		BinPath:  "/usr/local/bin/drop",
+		Verified: true,
+	}
+}
+
+func TestRecordKey(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "github.com/carabiner-dev/drop#drop", testRecord().Key())
+}
+
+func TestOpenFileMissing(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "installed.json")
+	inv, err := OpenFile(path)
+	require.NoError(t, err)
+	require.Equal(t, Version, inv.Version)
+	require.Empty(t, inv.Installs)
+}
+
+func TestRoundTrip(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "inventory", "installed.json")
+
+	inv, err := OpenFile(path)
+	require.NoError(t, err)
+	record := testRecord()
+	inv.Add(record)
+	require.NoError(t, inv.Save())
+
+	reloaded, err := OpenFile(path)
+	require.NoError(t, err)
+	require.Len(t, reloaded.Installs, 1)
+	got := reloaded.Get(record.Key())
+	require.NotNil(t, got)
+	require.Equal(t, record.Name, got.Name)
+	require.Equal(t, record.Digest, got.Digest)
+	require.Equal(t, record.BinPath, got.BinPath)
+	require.True(t, got.Verified)
+	require.False(t, got.InstalledAt.IsZero())
+	require.False(t, got.UpdatedAt.IsZero())
+}
+
+func TestAddPreservesInstalledAt(t *testing.T) {
+	t.Parallel()
+	inv := &Inventory{Version: Version, Installs: map[string]*Record{}}
+
+	first := testRecord()
+	first.InstalledAt = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	inv.Add(first)
+
+	update := testRecord()
+	update.Version = "v0.2.0"
+	inv.Add(update)
+
+	got := inv.Get(update.Key())
+	require.Equal(t, "v0.2.0", got.Version)
+	require.Equal(t, first.InstalledAt, got.InstalledAt, "installedAt must survive updates")
+	require.True(t, got.UpdatedAt.After(got.InstalledAt))
+}
+
+func TestRemove(t *testing.T) {
+	t.Parallel()
+	inv := &Inventory{Version: Version, Installs: map[string]*Record{}}
+	record := testRecord()
+	inv.Add(record)
+
+	require.True(t, inv.Remove(record.Key()))
+	require.Nil(t, inv.Get(record.Key()))
+	require.False(t, inv.Remove(record.Key()))
+}
+
+func TestOpenFileNewerVersion(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "installed.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"version": 99, "installs": {}}`), 0o600))
+
+	_, err := OpenFile(path)
+	require.Error(t, err)
+}
+
+func TestOpenFileCorrupt(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "installed.json")
+	require.NoError(t, os.WriteFile(path, []byte("not json"), 0o600))
+
+	_, err := OpenFile(path)
+	require.Error(t, err)
+}


### PR DESCRIPTION
We now record every successful drop install in a versioned JSON database stored in the user's config directory (~/.config/drop/installed.json). 

Each record keeps the repository coordinates, installable name and  exact asset, the artifact kind, a sha256 digest of the verified artifact and whether it passed policy verification, plus the binary  path or package format needed to later verify, update or uninstall  the app.

Reinstalls update the record in place, preserving the  original installation timestamp; writes are atomic and a recording failure does not fail an already completed installation.