### PR TITLE
Select the canonical binary and skip release metadata files 

### DIFF
--- a/pkg/drop/implementation.go
+++ b/pkg/drop/implementation.go
@@ -101,11 +101,18 @@ func (di *defaultImplementation) ChooseAsset(opts *GetOptions, client *github.Cl
 		// Found. Now check if it has variants for the local OS
 		if installable, ok := asset.(*github.Installable); ok {
 			var wantedVariant github.AssetDataProvider
+			var binaryVariant *github.Asset
 			sysPackageFormat := system.GetPreferredPackage(system.GetSystemOSFamily())
 
 			for _, variant := range installable.Variants {
 				// If the os or arch is not what we want, ignore it.
 				if variant.Os != opts.OS || variant.Arch != opts.Arch {
+					continue
+				}
+
+				// Signatures, SBOMs and other metadata files published
+				// along the artifacts are never chosen automatically.
+				if isMetadataFile(variant.GetName()) {
 					continue
 				}
 
@@ -128,26 +135,20 @@ func (di *defaultImplementation) ChooseAsset(opts *GetOptions, client *github.Cl
 					continue
 				}
 
-				// For expected binaries, we use the installer name
+				// Binaries win over packages and archives, but keep
+				// looking in case the release ships several flavors for
+				// the platform: the canonical one (shortest name) wins.
 				if packageType == "" && archiveType == "" {
-					opts.computedFilename = installable.GetName()
-					if variant.Os == system.OSWindows {
-						opts.computedFilename += ".exe"
+					if binaryVariant == nil || len(variant.GetName()) < len(binaryVariant.GetName()) {
+						binaryVariant = variant
 					}
-				} else {
-					// When handling packages or archives, keep the same name
-					opts.computedFilename = variant.GetName()
-				}
-
-				// If we are not looking for a specific type, and its a
-				// binary, return it immediately
-				if packageType == "" && archiveType == "" {
-					return variant, nil
+					continue
 				}
 
 				// If we are looking for a package, check if the asset matches
 				// the system format:
 				if opts.DownloadType == "p" && packageType == sysPackageFormat {
+					opts.computedFilename = variant.GetName()
 					return variant, nil
 				}
 
@@ -157,6 +158,15 @@ func (di *defaultImplementation) ChooseAsset(opts *GetOptions, client *github.Cl
 				} else if archiveType != "" {
 					wantedVariant = variant
 				}
+			}
+
+			// Binaries are downloaded under the installable name
+			if binaryVariant != nil {
+				opts.computedFilename = installable.GetName()
+				if binaryVariant.Os == system.OSWindows {
+					opts.computedFilename += ".exe"
+				}
+				return binaryVariant, nil
 			}
 
 			if wantedVariant != nil {

--- a/pkg/drop/install.go
+++ b/pkg/drop/install.go
@@ -79,6 +79,26 @@ type installCandidates struct {
 	HasOtherPkg bool
 }
 
+// metadataSuffixes are extensions of files published along release artifacts
+// (signatures, SBOMs, certificates, checksums...) that are never installable
+// even when their filenames carry platform markers.
+var metadataSuffixes = []string{
+	".json", ".jsonl", ".sig", ".pem", ".cert", ".crt", ".asc", ".pub",
+	".txt", ".md", ".sbom", ".bundle", ".sigstore", ".sha256", ".sha512",
+}
+
+// isMetadataFile returns true for release files that hold artifact metadata
+// instead of an installable artifact.
+func isMetadataFile(name string) bool {
+	name = strings.ToLower(name)
+	for _, suffix := range metadataSuffixes {
+		if strings.HasSuffix(name, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
 // classifyInstallCandidates inspects an installable's variants for the given
 // platform and classifies them into a binary candidate and a package candidate
 // matching the system's package format.
@@ -96,6 +116,17 @@ func classifyInstallCandidates(inst *github.Installable, osName, arch, pkgFormat
 		case archiveType != "":
 			cands.HasArchives = true
 		case packageType == "":
+			// Signatures, SBOMs and other metadata files also carry
+			// platform markers in their names but are not installable.
+			if isMetadataFile(variant.GetName()) {
+				continue
+			}
+			// When a release ships more than one binary flavor for the
+			// platform, prefer the canonical one: the shortest filename
+			// (e.g. cosign-linux-amd64 over cosign-linux-pivkey-amd64).
+			if cands.Binary != nil && len(cands.Binary.Asset.GetName()) <= len(variant.GetName()) {
+				continue
+			}
 			name := inst.GetName()
 			if variant.Os == system.OSWindows {
 				name += exeSuffix

--- a/pkg/drop/install_test.go
+++ b/pkg/drop/install_test.go
@@ -503,3 +503,50 @@ func TestRecordInstall(t *testing.T) {
 		})
 	}
 }
+
+// TestClassifyCosignStyleRelease locks in that releases shipping multiple
+// binary flavors plus metadata files (sigs, SBOMs, certs) select the
+// canonical binary and install it under the computed installable name.
+func TestClassifyCosignStyleRelease(t *testing.T) {
+	t.Parallel()
+	inst := &github.Installable{
+		Name: "cosign",
+		Variants: []*github.Asset{
+			{Name: "cosign-linux-amd64", Os: system.OSLinux, Arch: system.ArchAMD64},
+			{Name: "cosign-linux-amd64-keyless.sig", Os: system.OSLinux, Arch: system.ArchAMD64},
+			{Name: "cosign-linux-amd64.sig", Os: system.OSLinux, Arch: system.ArchAMD64},
+			{Name: "cosign-linux-pivkey-pkcs11key-amd64", Os: system.OSLinux, Arch: system.ArchAMD64},
+			{Name: "cosign-linux-pivkey-pkcs11key-amd64_3.1.1_linux_amd64.sbom.json", Os: system.OSLinux, Arch: system.ArchAMD64},
+			{Name: "cosign-2.6.0-1.x86_64.rpm", Os: system.OSLinux, Arch: system.ArchAMD64},
+			{Name: "cosign-2.6.0-1.x86_64.rpm-keyless.pem", Os: system.OSLinux, Arch: system.ArchAMD64},
+		},
+	}
+
+	cands := classifyInstallCandidates(inst, system.OSLinux, system.ArchAMD64, system.PackageRPM)
+
+	require.NotNil(t, cands.Binary)
+	require.Equal(t, "cosign-linux-amd64", cands.Binary.Asset.GetName(),
+		"the canonical binary must win over flavored binaries and metadata files")
+	require.Equal(t, "cosign", cands.Binary.InstallName,
+		"binaries must install under the computed installable name")
+	require.NotNil(t, cands.Package)
+	require.Equal(t, "cosign-2.6.0-1.x86_64.rpm", cands.Package.Asset.GetName())
+}
+
+func TestIsMetadataFile(t *testing.T) {
+	t.Parallel()
+	for file, expect := range map[string]bool{
+		"cosign-linux-amd64":                 false,
+		"cosign-windows-amd64.exe":           false,
+		"drop-1.0.0-1.x86_64.rpm":            false,
+		"cosign-linux-amd64.sig":             true,
+		"cosign-linux-amd64-keyless.SIG":     true,
+		"cosign_3.1.1_linux_amd64.sbom.json": true,
+		"checksums.txt":                      true,
+		"release.pem":                        true,
+		"slsa.intoto.jsonl":                  true,
+		"artifact.sigstore":                  true,
+	} {
+		require.Equal(t, expect, isMetadataFile(file), file)
+	}
+}

--- a/pkg/render/drivers/lstty.go
+++ b/pkg/render/drivers/lstty.go
@@ -50,6 +50,11 @@ func columnTable(w io.Writer, numCols int, data []string) {
 		cols = append(cols, cell)
 	}
 	if len(cols) != 0 {
+		// Pad the last row, the table formats every row to the full
+		// column count and renders missing cells as %!s(MISSING)
+		for len(cols) < numCols {
+			cols = append(cols, "")
+		}
 		rows = append(rows, cols)
 	}
 	tbl.SetRows(rows).Print()

--- a/pkg/render/drivers/lstty_test.go
+++ b/pkg/render/drivers/lstty_test.go
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package drivers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestColumnTablePadsLastRow(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		numCols int
+		data    []string
+	}{
+		{name: "partial-last-row", numCols: 3, data: []string{"one", "two", "three", "four"}},
+		{name: "single-cell", numCols: 3, data: []string{"lonely"}},
+		{name: "full-rows", numCols: 3, data: []string{"a1", "a2", "a3"}},
+		{name: "two-columns", numCols: 2, data: []string{"b1", "b2", "b3"}},
+		{name: "empty", numCols: 3, data: []string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var b strings.Builder
+			columnTable(&b, tc.numCols, tc.data)
+			out := b.String()
+			require.NotContains(t, out, "MISSING")
+			for _, cell := range tc.data {
+				require.Contains(t, out, cell)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request improves the robustness of asset selection and table rendering in the project. The most significant changes ensure that only valid installable artifacts are chosen (excluding metadata files like signatures and SBOMs), that the canonical binary is selected when multiple flavors exist, and that table rendering no longer displays formatting errors when the last row is incomplete. Comprehensive tests have been added to lock in these behaviors.

**Asset selection and installability improvements:**

* Added `isMetadataFile` logic and `metadataSuffixes` list in `pkg/drop/install.go` to reliably identify and exclude metadata files (e.g., `.sig`, `.sbom`, `.json`) from being selected as installable artifacts. This prevents accidental installation of non-executable files. [[1]](diffhunk://#diff-0e22cc28ee93451d8a1fe27ed8bf12747b439bc5be33261050670bf3346b843eR82-R101) [[2]](diffhunk://#diff-0e22cc28ee93451d8a1fe27ed8bf12747b439bc5be33261050670bf3346b843eR119-R129)
* Updated `ChooseAsset` in `pkg/drop/implementation.go` to skip metadata files and ensure that, when multiple binary variants exist, the canonical binary (with the shortest filename) is selected and installed under the correct name. Packages are still correctly chosen based on system preferences. [[1]](diffhunk://#diff-93ece1fad2c939ee44b24af97d6e51fa24af02711b33fab955769241d805fb4bR104) [[2]](diffhunk://#diff-93ece1fad2c939ee44b24af97d6e51fa24af02711b33fab955769241d805fb4bR113-R118) [[3]](diffhunk://#diff-93ece1fad2c939ee44b24af97d6e51fa24af02711b33fab955769241d805fb4bL131-R151) [[4]](diffhunk://#diff-93ece1fad2c939ee44b24af97d6e51fa24af02711b33fab955769241d805fb4bR163-R171)

**Testing enhancements:**

* Added `TestClassifyCosignStyleRelease` and `TestIsMetadataFile` in `pkg/drop/install_test.go` to verify that only the canonical binary is selected among multiple flavors and that metadata files are never chosen for installation.

**Table rendering fixes:**

* Modified `columnTable` in `pkg/render/drivers/lstty.go` to pad the last row with empty strings if it is incomplete, preventing `%!s(MISSING)` formatting errors in output.
* Added `TestColumnTablePadsLastRow` in `pkg/render/drivers/lstty_test.go` to ensure table rendering never outputs "MISSING" and that all provided data appears in the output.